### PR TITLE
Fix Typespec of reduce functions

### DIFF
--- a/lib/chisel/renderer.ex
+++ b/lib/chisel/renderer.ex
@@ -92,7 +92,7 @@ defmodule Chisel.Renderer do
           reduce_pixel :: reduce_pixel_fun,
           opts :: draw_options()
         ) ::
-          {x :: integer(), y :: integer()}
+          {acc :: acc(), x :: integer(), y :: integer()}
   def reduce_draw_text(text, tlx, tly, %Font{} = font, acc, reduce_pixel, opts \\ [])
       when is_binary(text) do
     opts = Keyword.merge(@draw_default_opts, opts)
@@ -132,7 +132,7 @@ defmodule Chisel.Renderer do
           reduce_pixel :: reduce_pixel_fun,
           opts :: draw_options()
         ) ::
-          {x :: integer(), y :: integer()}
+          {acc :: acc(), x :: integer(), y :: integer()}
   def reduce_draw_char(codepoint, clx, cly, %Font{} = font, acc, reduce_pixel, opts \\ [])
       when is_integer(codepoint) do
     opts = Keyword.merge(@draw_default_opts, opts)


### PR DESCRIPTION
The type specification of `Chisel.Renderer.reduce_draw_text` and `Chisel.Renderer.reduce_draw_char` have the wrong return type.